### PR TITLE
Feature/132735 - Adiciona configuração do STATIC_ROOT

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -102,6 +102,10 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = 'static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static'),
+]
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
Este PR:

Adiciona configuração do STATIC_ROOT.

Referência AzureDevOps: [AB#132735](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/132735)