### PR TITLE
test(144149): Adiciona refatoração dos testes unitários após a retirada do campo vagas sem efeitos

### DIFF
--- a/concursos/tests/models/test_autorizacao_publicada.py
+++ b/concursos/tests/models/test_autorizacao_publicada.py
@@ -9,9 +9,7 @@ def test_autorizacao_publicada_model_fields():
     expected_fields = [
         'uuid',
         'cargo',
-        'vagas_sem_efeito',
         'autorizacoes',
-        'autorizacoes_sem_efeito',
         'data_autorizacao',
         'observacao',
         'criado_em',

--- a/concursos/tests/serializers/test_autorizacao_publicada_serializer.py
+++ b/concursos/tests/serializers/test_autorizacao_publicada_serializer.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.django_db
 def test_autorizacao_publicada_serializer_fields():
     obj = AutorizacaoPublicada.objects.create()
     data = AutorizacaoPublicadaSerializer(obj).data
-    for field in ['uuid', 'cargo', 'vagas_sem_efeito', 'autorizacoes', 'autorizacoes_sem_efeito', 'data_autorizacao', 'observacao', 'criado_em', 'atualizado_em']:
+    for field in ['uuid', 'cargo', 'autorizacoes', 'data_autorizacao', 'observacao', 'criado_em', 'atualizado_em']:
         assert field in data
 
 
@@ -16,9 +16,7 @@ def test_autorizacao_publicada_create_with_valid_cargo():
     cargo = Cargo.objects.create(nome='Teste')
     payload = {
         'cargo': str(cargo.uuid),
-        'vagas_sem_efeito': False,
         'autorizacoes': 3,
-        'autorizacoes_sem_efeito': 1,
         'observacao': 'Obs',
     }
     serializer = AutorizacaoPublicadaSerializer(data=payload)
@@ -26,4 +24,3 @@ def test_autorizacao_publicada_create_with_valid_cargo():
     obj = serializer.save()
     assert obj.cargo == cargo
     assert obj.autorizacoes == 3
-    assert obj.autorizacoes_sem_efeito == 1

--- a/concursos/tests/views/test_autorizacoes_publicadas_view.py
+++ b/concursos/tests/views/test_autorizacoes_publicadas_view.py
@@ -8,9 +8,7 @@ pytestmark = pytest.mark.django_db
 
 def criar_autorizacao(cargo: Cargo | None = None, **kwargs) -> AutorizacaoPublicada:
     defaults = dict(
-        vagas_sem_efeito=False,
         autorizacoes=2,
-        autorizacoes_sem_efeito=1,
         observacao='Obs teste',
     )
     defaults.update(kwargs)
@@ -65,9 +63,7 @@ def test_create_autorizacao_publicada_success_with_cargo(api_client):
     url = reverse('autorizacao-publicada-list')
     payload = {
         'cargo': str(cargo.uuid),
-        'vagas_sem_efeito': True,
         'autorizacoes': 5,
-        'autorizacoes_sem_efeito': 0,
         'data_autorizacao': '2026-01-29',
         'observacao': 'Criado via teste',
     }
@@ -76,7 +72,6 @@ def test_create_autorizacao_publicada_success_with_cargo(api_client):
     created = AutorizacaoPublicada.objects.get(uuid=resp.data['uuid'])
     assert created.cargo == cargo
     assert created.autorizacoes == 5
-    assert created.vagas_sem_efeito is True
 
 
 def test_create_autorizacao_publicada_invalid_cargo(api_client):
@@ -92,21 +87,17 @@ def test_create_autorizacao_publicada_invalid_cargo(api_client):
 
 
 def test_patch_autorizacao_publicada_success(api_client):
-    obj = criar_autorizacao(None, autorizacoes=2, autorizacoes_sem_efeito=1, observacao='old')
+    obj = criar_autorizacao(None, autorizacoes=2, observacao='old')
     url = reverse('autorizacao-publicada-detail', kwargs={'pk': obj.uuid})
     payload = {
-        'vagas_sem_efeito': True,
         'autorizacoes': 7,
-        'autorizacoes_sem_efeito': 3,
         'data_autorizacao': '2026-01-29',
         'observacao': 'nova',
     }
     resp = api_client.patch(url, payload, format='json')
     assert resp.status_code == status.HTTP_200_OK
     obj.refresh_from_db()
-    assert obj.vagas_sem_efeito is True
     assert obj.autorizacoes == 7
-    assert obj.autorizacoes_sem_efeito == 3
     assert str(obj.data_autorizacao) == '2026-01-29'
     assert obj.observacao == 'nova'
 

--- a/concursos/tests/views/test_cargos_view.py
+++ b/concursos/tests/views/test_cargos_view.py
@@ -73,9 +73,9 @@ def test_autorizacoes_publicadas_agrupa_e_integra_ms_escolhas(authenticated_clie
     cargo_a = Cargo.objects.create(nome='Cargo A', codigo=1001)
     cargo_b = Cargo.objects.create(nome='Cargo B', codigo=1002)
     # cria autorizações publicadas locais
-    AutorizacaoPublicada.objects.create(cargo=cargo_a, autorizacoes=2, autorizacoes_sem_efeito=1, data_autorizacao=date(2026, 1, 1))
-    AutorizacaoPublicada.objects.create(cargo=cargo_a, autorizacoes=1, autorizacoes_sem_efeito=0, data_autorizacao=date(2026, 1, 15))
-    AutorizacaoPublicada.objects.create(cargo=cargo_b, autorizacoes=5, autorizacoes_sem_efeito=2, data_autorizacao=date(2025, 12, 31))
+    AutorizacaoPublicada.objects.create(cargo=cargo_a, autorizacoes=2, data_autorizacao=date(2026, 1, 1))
+    AutorizacaoPublicada.objects.create(cargo=cargo_a, autorizacoes=1, data_autorizacao=date(2026, 1, 15))
+    AutorizacaoPublicada.objects.create(cargo=cargo_b, autorizacoes=5, data_autorizacao=date(2025, 12, 31))
 
     # mock do serviço externo retornando totais de escolhas por cargo
     payload = {"1001": 3, "1002": 1}
@@ -100,9 +100,7 @@ def test_autorizacoes_publicadas_agrupa_e_integra_ms_escolhas(authenticated_clie
         assert b['total_escolhas'] == payload['1002']
         # verifica agregações locais (somas)
         assert a['autorizacoes'] == 3  # 2 + 1
-        assert a['autorizacoes_sem_efeito'] == 1  # 1 + 0
         assert a['data_autorizacao_mais_recente'] == '2026-01-15'
         assert b['autorizacoes'] == 5
-        assert b['autorizacoes_sem_efeito'] == 2
         assert b['data_autorizacao_mais_recente'] == '2025-12-31'
 


### PR DESCRIPTION
PR que adiciona:

- Refatoração testes unitários da retirada de vagas sem efeito.

Referência AzureDevOps: [AB#144149](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/144149) [AB#144408](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/144408)