### PR TITLE
feat(153513): muda situação concurso ao criar convocação

### DIFF
--- a/apps/concursos/api/views.py
+++ b/apps/concursos/api/views.py
@@ -5,20 +5,33 @@ from __future__ import annotations
 from typing import Any
 
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import viewsets
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
+from concursos.constants import (
+    CONCURSO_SITUACAO_COMPLETO,
+    CONCURSO_SITUACAO_EM_ANDAMENTO,
+)
 from concursos.filters import ConcursoFilterSet
 from concursos.models import Concurso
+from concursos.repository import ConcursosRepository
 from concursos.serializers import (
+    ConcursoAtualizarSituacaoSerializer,
     ConcursoListSerializer,
     ConcursoSelectSerializer,
     ConcursoSerializer,
 )
 from core.utils import CustomPagination
+
+# Transições permitidas: situação alvo -> situação de origem exigida
+_TRANSICOES_PERMITIDAS = {
+    CONCURSO_SITUACAO_EM_ANDAMENTO: CONCURSO_SITUACAO_COMPLETO,
+    CONCURSO_SITUACAO_COMPLETO: CONCURSO_SITUACAO_EM_ANDAMENTO,
+}
 
 
 class ConcursoViewSet(viewsets.ModelViewSet):
@@ -57,3 +70,22 @@ class ConcursoViewSet(viewsets.ModelViewSet):
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    @action(detail=True, methods=["patch"], url_path="atualizar-situacao")
+    def atualizar_situacao(
+        self, request: Request, pk: str | None = None
+    ) -> Response:
+        """Aplica transição de situação se o estado atual permitir."""
+        concurso = self.get_object()
+        serializer = ConcursoAtualizarSituacaoSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        situacao_alvo = serializer.validated_data["situacao"]
+
+        origem_exigida = _TRANSICOES_PERMITIDAS.get(situacao_alvo)
+        if origem_exigida is not None and concurso.situacao == origem_exigida:
+            ConcursosRepository.atualizar_situacao(concurso, situacao_alvo)
+            concurso.refresh_from_db()
+
+        return Response(
+            ConcursoSerializer(concurso).data, status=status.HTTP_200_OK
+        )

--- a/apps/concursos/repository.py
+++ b/apps/concursos/repository.py
@@ -58,3 +58,9 @@ class ConcursosRepository:
         """Busca um concurso pelo UUID e devolve a resposta serializada."""
         concurso = Concurso.objects.filter(uuid=concurso_uuid).first()
         return cls.montar_resposta(concurso) if concurso else None
+
+    @classmethod
+    def atualizar_situacao(cls, concurso: Concurso, situacao: str) -> None:
+        """Atualiza a situação do concurso e persiste o campo."""
+        concurso.situacao = situacao
+        concurso.save(update_fields=["situacao"])

--- a/apps/concursos/serializers.py
+++ b/apps/concursos/serializers.py
@@ -11,6 +11,7 @@ from rest_framework.validators import UniqueValidator
 
 from cargos.repository import CargoRepository
 from cargos.serializers import CargoListSerializer, CargoSelectSerializer
+from concursos.constants import CONCURSO_SITUACAO_CHOICES
 from concursos.models import Concurso
 
 logger = logging.getLogger(__name__)
@@ -151,3 +152,9 @@ class ConcursoSelectSerializer(serializers.ModelSerializer):
 
         model = Concurso
         fields = ["value", "label", "cargos", "numero_processo", "codigo"]
+
+
+class ConcursoAtualizarSituacaoSerializer(serializers.Serializer):
+    """Valida o campo situacao para a transição de estado do concurso."""
+
+    situacao = serializers.ChoiceField(choices=CONCURSO_SITUACAO_CHOICES)

--- a/apps/concursos/tests/test_views.py
+++ b/apps/concursos/tests/test_views.py
@@ -296,3 +296,88 @@ def test_patch_numero_processo_proprio_permite(authenticated_client):
         url, {"nome": "Renomeado", "numero_processo": "55555"}
     )
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_atualizar_situacao_de_completo_para_em_andamento_aplica(
+    authenticated_client,
+):
+    """Aplica a transição quando o concurso está COMPLETO."""
+    concurso = Concurso.objects.create(nome="Concurso X", situacao="COMPLETO")
+    url = reverse("concurso-atualizar-situacao", args=[concurso.uuid])
+
+    response = authenticated_client.patch(
+        url, {"situacao": "EM_ANDAMENTO"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["situacao"] == "EM_ANDAMENTO"
+    concurso.refresh_from_db()
+    assert concurso.situacao == "EM_ANDAMENTO"
+
+
+def test_atualizar_situacao_de_em_andamento_para_completo_aplica(
+    authenticated_client,
+):
+    """Aplica a transição quando o concurso está EM_ANDAMENTO."""
+    concurso = Concurso.objects.create(
+        nome="Concurso Y", situacao="EM_ANDAMENTO"
+    )
+    url = reverse("concurso-atualizar-situacao", args=[concurso.uuid])
+
+    response = authenticated_client.patch(
+        url, {"situacao": "COMPLETO"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["situacao"] == "COMPLETO"
+    concurso.refresh_from_db()
+    assert concurso.situacao == "COMPLETO"
+
+
+def test_atualizar_situacao_ignora_quando_estado_atual_nao_e_o_esperado(
+    authenticated_client,
+):
+    """Não altera quando o concurso não está no estado de origem esperado."""
+    concurso = Concurso.objects.create(
+        nome="Concurso Z", situacao="INCOMPLETO"
+    )
+    url = reverse("concurso-atualizar-situacao", args=[concurso.uuid])
+
+    response = authenticated_client.patch(
+        url, {"situacao": "EM_ANDAMENTO"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["situacao"] == "INCOMPLETO"
+    concurso.refresh_from_db()
+    assert concurso.situacao == "INCOMPLETO"
+
+
+def test_atualizar_situacao_ignora_quando_completo_nao_esta_em_andamento(
+    authenticated_client,
+):
+    """Não reverte para COMPLETO se o concurso não estiver EM_ANDAMENTO."""
+    concurso = Concurso.objects.create(
+        nome="Concurso W", situacao="FINALIZADO"
+    )
+    url = reverse("concurso-atualizar-situacao", args=[concurso.uuid])
+
+    response = authenticated_client.patch(
+        url, {"situacao": "COMPLETO"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    concurso.refresh_from_db()
+    assert concurso.situacao == "FINALIZADO"
+
+
+def test_atualizar_situacao_rejeita_valor_invalido(authenticated_client):
+    """Retorna 400 quando situacao não é um valor válido do enum."""
+    concurso = Concurso.objects.create(nome="Concurso V", situacao="COMPLETO")
+    url = reverse("concurso-atualizar-situacao", args=[concurso.uuid])
+
+    response = authenticated_client.patch(
+        url, {"situacao": "NAO_EXISTE"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## O que foi feito

- Adiciona action `PATCH /api/v1/concursos/<uuid>/atualizar-situacao/` em `ConcursoViewSet`.
- Aplica a transição de situação apenas se o concurso estiver no estado de origem esperado:
  - `COMPLETO` → `EM_ANDAMENTO`
  - `EM_ANDAMENTO` → `COMPLETO`
- Transições fora do par esperado são silenciosamente ignoradas (retorna 200 com o estado atual, sem alterar).
- Novo `ConcursoAtualizarSituacaoSerializer` valida o campo `situacao` contra `CONCURSO_SITUACAO_CHOICES`.
- Novo `ConcursosRepository.atualizar_situacao` persiste a mudança (`update_fields=["situacao"]`).

## Contexto

Endpoint consumido pelo MS-Convocação para sinalizar `EM_ANDAMENTO` ao criar um processo e `COMPLETO` ao excluir a última convocação ativa de um concurso.




[AB#153513](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/153513)
[AB#153506](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/153506)